### PR TITLE
Fix mongo state builder

### DIFF
--- a/states/eve_state_mongo/src/main/java/com/almende/eve/state/mongo/MongoStateBuilder.java
+++ b/states/eve_state_mongo/src/main/java/com/almende/eve/state/mongo/MongoStateBuilder.java
@@ -73,9 +73,9 @@ public class MongoStateBuilder extends AbstractCapabilityBuilder<MongoState> {
                     if (!instances.containsKey(key)) {
                         try {
                             // initialization of client & jongo
-                            MongoClient client = getClientInstance(config.getHosts(), null);
-                            final MongoStateProvider result = new MongoStateProvider(getJongo(client, 
-                                config.getDatabase()), config);
+                            MongoClient client = getClientInstance(config.getHosts(), config.getMongoCredentials());
+                            final MongoStateProvider result = new MongoStateProvider(getJongo(client, config.getDatabase()),
+                                config.getCollection());
                             if (result != null) {
                                 instances.put(key, result);
                             }
@@ -90,13 +90,14 @@ public class MongoStateBuilder extends AbstractCapabilityBuilder<MongoState> {
         }
         
         /**
-         * Returns a single instance of the MongoClient
-         * 
-         * @param hosts
-         *            Arraynode of "host" and corresponding "ports"
-         * @return
-         * @throws UnknownHostException
-         */
+     * Returns a single instance of the MongoClient. Expects all hosts to be
+     * given at first instance creation time.
+     * 
+     * @param hosts
+     *            Arraynode of "host" and corresponding "ports"
+     * @return
+     * @throws UnknownHostException
+     */
         public static MongoClient getClientInstance(final ArrayNode hosts, final List<MongoCredential> credentials)
             throws UnknownHostException {
     
@@ -109,6 +110,12 @@ public class MongoStateBuilder extends AbstractCapabilityBuilder<MongoState> {
             return client;
         }
         
+        /**
+         * Gets a new instance of Jongo connection for the given dataBaseName
+         * @param client
+         * @param dataBaseName
+         * @return
+         */
         public static Jongo getJongo(final MongoClient client, String dataBaseName) {
     
             return new Jongo(client.getDB(dataBaseName), new JacksonMapper.Builder().addModifier(new MapperModifier() {
@@ -137,7 +144,7 @@ public class MongoStateBuilder extends AbstractCapabilityBuilder<MongoState> {
             }
             return addresses;
         }
-
+        
 	/**
 	 * A service for managing MemoryState objects.
 	 */
@@ -157,9 +164,9 @@ public class MongoStateBuilder extends AbstractCapabilityBuilder<MongoState> {
                  * @throws UnknownHostException
                  *             the unknown host exception
                  */
-                public MongoStateProvider(final Jongo jongo, final MongoStateConfig config) throws UnknownHostException {
+                public MongoStateProvider(final Jongo jongo, final String collectionName) throws UnknownHostException {
         
-                    collectionName = config.getCollection();
+                    this.collectionName = collectionName;
                     this.jongo = jongo;
                 }
 

--- a/states/eve_state_mongo/src/main/java/com/almende/eve/state/mongo/MongoStateBuilder.java
+++ b/states/eve_state_mongo/src/main/java/com/almende/eve/state/mongo/MongoStateBuilder.java
@@ -90,16 +90,22 @@ public class MongoStateBuilder extends AbstractCapabilityBuilder<MongoState> {
                 }
             }
         }
-        
+
         /**
-         * Returns a single instance of the MongoClient. Expects all hosts to be
-         * given at first instance creation time.
-         * 
-         * @param hosts
-         *            Arraynode of "host" and corresponding "ports"
-         * @return
-         * @throws UnknownHostException
-         */
+     * Returns a single instance of the MongoClient. Expects all hosts to be
+     * given at first instance creation time.
+     * 
+     * @param hosts
+     *            ArrayNode of hosts must have host:<string> and port:<int>
+     * @param credentials
+     *            MongoCredentials which is used to access the db
+     * @param hostKey
+     *            Optional. If a new MongoClient instance is needed, pass a
+     *            unique key here. Ideally one MongoClient instance is
+     *            sufficient per JVM
+     * @return
+     * @throws UnknownHostException
+     */
         public static MongoClient getClientInstance(final ArrayNode hosts, final List<MongoCredential> credentials,
             String hostKey) throws UnknownHostException {
     

--- a/states/eve_state_mongo/src/main/java/com/almende/eve/state/mongo/MongoStateConfig.java
+++ b/states/eve_state_mongo/src/main/java/com/almende/eve/state/mongo/MongoStateConfig.java
@@ -4,14 +4,16 @@
  */
 package com.almende.eve.state.mongo;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.logging.Logger;
-
 import com.almende.eve.state.StateConfig;
 import com.almende.util.jackson.JOM;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.mongodb.MongoCredential;
 
 /**
  * The Class MongoStateConfig.
@@ -199,4 +201,49 @@ public class MongoStateConfig extends StateConfig {
 		}
 		return "agents";
 	}
+	
+        /**
+         * Gets the credentials for the mongoDb from the config
+         * 
+         * @return An ArrayNode of credentials. Where each credential is an
+         *         objectNode
+         */
+        public ArrayNode getCredentials() {
+    
+            if (this.has("credentials") && this.get("credentials") instanceof ArrayNode) {
+                return (ArrayNode) this.get("credentials");
+            }
+            return null;
+        }
+        
+        /**
+         * Sets the credentials to the current config
+         * @param credentials
+         */
+        public void setCredentials(ArrayNode credentials) {
+            this.set("credentials", credentials);
+        }
+        
+        /**
+         * Helper method to fetch the list of Mongocredentials based on the config
+         * 
+         * @param credentials
+         * @return
+         */
+        @JsonIgnore
+        public List<MongoCredential> getMongoCredentials() {
+    
+            ArrayNode credentials = getCredentials();
+            List<MongoCredential> mongoCredentials = null;
+            if (credentials != null) {
+                mongoCredentials = new ArrayList<MongoCredential>(1);
+                for (JsonNode credential : credentials) {
+                    if (credential.has("user") && credential.has("database") && credential.has("password")) {
+                        mongoCredentials.add(MongoCredential.createMongoCRCredential(credential.get("user").asText(),
+                            credential.get("database").asText(), credential.get("password").asText().toCharArray()));
+                    }
+                }
+            }
+            return mongoCredentials;
+        }
 }

--- a/states/eve_state_mongo/src/main/java/com/almende/eve/state/mongo/MongoStateConfig.java
+++ b/states/eve_state_mongo/src/main/java/com/almende/eve/state/mongo/MongoStateConfig.java
@@ -225,6 +225,28 @@ public class MongoStateConfig extends StateConfig {
         }
         
         /**
+         * If this agent has to have its own unique MongoClient instance, this field should
+         * be set in eve.yaml. Else it will load a single instance of MongoClient
+         * 
+         * @return
+         */
+        public String getMongoClientLabel() {
+    
+            if (this.has("mongoClientKey")) {
+                return this.get("mongoClientKey").asText();
+            }
+            return null;
+        }
+        
+        /**
+         * Sets the mongoClientLabel to the current config
+         * @param credentials
+         */
+        public void setMongoClientLabel(String mongoClientKey) {
+            this.put("mongoClientKey", mongoClientKey);
+        }
+        
+        /**
          * Helper method to fetch the list of Mongocredentials based on the config
          * 
          * @param credentials


### PR DESCRIPTION
- Add a single instance fetch. So that all clients use the same MongoClient instance
- Can add mongo credentials to the config yaml
