### PR TITLE
Fix MongoState.delete(Boolean)

### DIFF
--- a/states/eve_state_mongo/src/main/java/com/almende/eve/state/mongo/MongoState.java
+++ b/states/eve_state_mongo/src/main/java/com/almende/eve/state/mongo/MongoState.java
@@ -434,4 +434,14 @@ public class MongoState extends AbstractState<JsonNode> implements State {
 		timestamp = now;
 		return updatedExisting;
 	}
+
+	@Override
+	public void delete(Boolean instanceOnly) {
+		if (provider != null) {
+			if(!instanceOnly) {
+				clear();
+			}
+			provider.delete(this, instanceOnly);
+		}
+	}
 }


### PR DESCRIPTION
MongoState did not override AbstractState.destroy(Boolean). In AbstractState.destroy(Boolean) is the variable 'service' used, which is/can become null. The MongoState class uses primarily the 'provider' variable. This caused agents to be deleted from the InstantiationService, but not from the database.

Note: this should maybe be fixed in another way by calling getService() instead of using the 'provider' variable?
